### PR TITLE
Refactor to make unit-testable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
   - npm run depcheck
   - npm run depcheck-web
   - npm run lint
+  - npm run test

--- a/bin/depcheck-web
+++ b/bin/depcheck-web
@@ -2,9 +2,4 @@
 
 /* eslint-disable no-console */
 
-require('../dist/index').default(
-  process.argv.slice(2),
-  console.log,
-  console.error,
-  process.env,
-  process.exit);
+require('../dist/cli').default(process);

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "report"
   ],
   "dependencies": {
-    "request": "^2.67.0"
+    "superagent": "^1.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,11 @@
     "babel-eslint": "^4.1.5",
     "babel-preset-es2015": "^6.1.18",
     "babel-preset-stage-2": "^6.1.18",
+    "blue-tape": "^0.1.10",
     "depcheck": "^0.5.10",
     "eslint": "^1.10.1",
-    "eslint-config-airbnb": "^1.0.0"
+    "eslint-config-airbnb": "^1.0.0",
+    "string-to-stream": "^1.0.1",
+    "superagent-mocker": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "depcheck-web": "bin/depcheck-web"
   },
   "scripts": {
+    "test": "babel-node ./test/cli.js",
     "lint": "eslint src/",
     "compile": "babel src/ -d dist/",
     "depcheck": "depcheck",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,33 @@
+import readStream from './stream';
+import getSettings from './setting';
+import postWebReport from './index';
+import { inspect } from 'util';
+
+function parseArgv(argv) {
+  return new Promise(resolve =>
+    resolve({
+      report: argv[2] || '', // empty string
+      baseUrl: argv[3] || 'https://depcheck.tk',
+    }));
+}
+
+export default function cli({ argv, stdin, stdout, stderr, env, exit }) {
+  return Promise.all([
+    readStream(stdin).then(JSON.parse),
+    getSettings(env),
+    parseArgv(argv),
+  ]).then(([result, settings, args]) => postWebReport({
+    token: env.DEPCHECK_TOKEN,
+    baseUrl: args.baseUrl,
+    url: settings.url,
+    branch: settings.branch,
+    report: args.report,
+    result,
+  })).then(() => {
+    stdout.write('Post web report succeed.');
+    exit(0);
+  }, message => {
+    stderr.write(inspect(message));
+    exit(-1);
+  });
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,39 +1,6 @@
 import request from 'request';
-import readStdin from './stdin';
 
-function getSettings(env) {
-  return new Promise((resolve, reject) => {
-    // TODO web report only supports Travis CI and GitHub now
-    if (env.TRAVIS === 'true') {
-      return resolve({
-        url: `/github/${env.TRAVIS_REPO_SLUG}`,
-        branch: env.TRAVIS_BRANCH,
-        pullRequest: env.TRAVIS_PULL_REQUEST === 'false'
-          ? false
-          : parseInt(env.TRAVIS_PULL_REQUEST, 10),
-      });
-    }
-
-    return reject('Build environment is not supported yet, please report issue to https://github.com/depcheck/depcheck-web');
-  });
-}
-
-function validatePullRequest(settings) {
-  return new Promise((resolve, reject) =>
-    settings.pullRequest
-    ? reject('Skip posting depcheck report to web service because it runs in a pull request.')
-    : resolve(settings));
-}
-
-function parseArgv(argv) {
-  return new Promise(resolve =>
-    resolve({
-      report: argv[0] || '',
-      baseUrl: argv[1] || 'https://depcheck.tk',
-    }));
-}
-
-function postWebReport({
+export default function postWebReport({
   token,
   baseUrl,
   url,
@@ -62,25 +29,4 @@ function postWebReport({
 
       resolve(result);
     }));
-}
-
-export default function main(argv, log, error, env, exit) {
-  return Promise.all([
-    readStdin().then(JSON.parse),
-    getSettings(env).then(validatePullRequest),
-    parseArgv(argv),
-  ]).then(([result, settings, args]) => postWebReport({
-    token: env.DEPCHECK_TOKEN,
-    baseUrl: args.baseUrl,
-    url: settings.url,
-    branch: settings.branch,
-    report: args.report,
-    result,
-  })).then(() => {
-    log('Post web report succeed.');
-    exit(0);
-  }, message => {
-    error(message);
-    exit(-1);
-  });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import request from 'request';
+import request from 'superagent';
 
 export default function postWebReport({
   token,
@@ -9,24 +9,14 @@ export default function postWebReport({
   result,
   }) {
   return new Promise((resolve, reject) =>
-    request({
-      baseUrl,
-      url,
-      method: 'POST',
-      json: true,
-      body: {
-        token,
-        branch,
-        report,
-        result,
-      },
-    }, (err, res, body) => {
-      if (err) {
-        reject(err);
-      } else if (res.statusCode !== 200) {
-        reject(body);
-      }
-
-      resolve(result);
-    }));
+    request
+    .post(`${baseUrl.replace(/\/+$/, '')}${url}`)
+    .accept('json')
+    .send({
+      token,
+      branch,
+      report,
+      result,
+    })
+    .end(err => err ? reject(err.response.body) : resolve(result)));
 }

--- a/src/setting.js
+++ b/src/setting.js
@@ -1,0 +1,26 @@
+function getSettings(env) {
+  return new Promise((resolve, reject) => {
+    // TODO web report only supports Travis CI and GitHub now
+    if (env.TRAVIS === 'true') {
+      return resolve({
+        url: `/github/${env.TRAVIS_REPO_SLUG}`,
+        branch: env.TRAVIS_BRANCH,
+        pullRequest: env.TRAVIS_PULL_REQUEST === 'false'
+          ? false
+          : parseInt(env.TRAVIS_PULL_REQUEST, 10),
+      });
+    }
+
+    return reject('Build environment is not supported yet, please report issue to https://github.com/depcheck/depcheck-web');
+  });
+}
+
+function validatePullRequest(settings) {
+  return new Promise((resolve, reject) =>
+    settings.pullRequest
+    ? reject('Skip posting depcheck report to web service because it runs in a pull request.')
+    : resolve(settings));
+}
+
+export default (env) =>
+  getSettings(env).then(validatePullRequest);

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,17 +1,17 @@
-export default function readStdin() {
+export default function readStream(stream) {
   return new Promise(resolve => {
     const chunks = [];
 
-    process.stdin.setEncoding('utf8');
+    stream.setEncoding('utf8');
 
-    process.stdin.on('readable', () => {
-      const chunk = process.stdin.read();
+    stream.on('readable', () => {
+      const chunk = stream.read();
       if (chunk !== null) {
         chunks.push(chunk);
       }
     });
 
-    process.stdin.on('end', () => {
+    stream.on('end', () => {
       const stdin = chunks.join('');
       resolve(stdin);
     });

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,33 @@
+import test from 'blue-tape';
+import request from 'superagent';
+import mocker from 'superagent-mocker';
+
+import cli from '../src/cli';
+import mockProcess from './process';
+
+const mock = mocker(request);
+
+test('should post the input and succeed', assert => {
+  assert.timeoutAfter(5000); // 5 seconds
+
+  const processMocker = mockProcess({
+    input: {
+      dependencies: [],
+    },
+    env: {
+      TRAVIS: 'true',
+      TRAVIS_REPO_SLUG: 'tester/project',
+      TRAVIS_BRANCH: 'test',
+      TRAVIS_PULL_REQUEST: 'false',
+      DEPCHECK_TOKEN: 'project-token',
+    },
+  });
+
+  mock.post('https://depcheck.tk/github/tester/project', () => null);
+  return cli(processMocker)
+    .then(() => assert.equal(processMocker.exit.value, 0))
+    .then(() => assert.equal(processMocker.stdout.value, 'Post web report succeed.'))
+    .then(() => assert.equal(processMocker.stderr.value, ''))
+    .catch(error => assert.fail(error))
+    .then(() => mock.clearRoutes());
+});

--- a/test/process.js
+++ b/test/process.js
@@ -1,0 +1,42 @@
+import str from 'string-to-stream';
+
+function writable() {
+  const storage = [];
+  return {
+    write(data) {
+      storage.push(data);
+    },
+    get value() {
+      return storage.join('');
+    },
+  };
+}
+
+function storeFunction() {
+  let storage = null;
+
+  function fn(value) {
+    storage = value;
+  }
+
+  Object.defineProperty(fn, 'value', {
+    get: () => storage,
+  });
+
+  return fn;
+}
+
+export default function mockProcess({
+  argv = [],
+  env = {},
+  input = null,
+  }) {
+  return {
+    argv: [null, null].concat(argv),
+    env,
+    stdin: str(JSON.stringify(input)),
+    stdout: writable(),
+    stderr: writable(),
+    exit: storeFunction(),
+  };
+}


### PR DESCRIPTION
- Refactor the code to separated files.
- Convert the request tool to `superagent`, which is more lightweight and easier to test.
- Add a very simple and basic test case.
- Integrate the test into Travis build.
